### PR TITLE
Feat: Database Migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,12 +1,14 @@
 source 'https://rubygems.org'
 
 gem "graphql"
+gem "rake"
 gem "sinatra"
 gem "puma"
 
 group :data do
   gem 'pg'
   gem 'sequel'
+  gem 'sequel-rake'
   # TODO: Do we need Redis?
   # gem 'ohm'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,15 +3,21 @@ GEM
   specs:
     graphql (1.7.3)
     mustermann (1.0.1)
+    pg (0.21.0)
     puma (3.10.0)
     rack (2.0.3)
     rack-protection (2.0.0)
       rack
+    rake (12.0.0)
+    sequel (5.0.0)
+    sequel-rake (0.2.0)
+      thor (~> 0.19)
     sinatra (2.0.0)
       mustermann (~> 1.0)
       rack (~> 2.0)
       rack-protection (= 2.0.0)
       tilt (~> 2.0)
+    thor (0.20.0)
     tilt (2.0.8)
 
 PLATFORMS
@@ -19,7 +25,11 @@ PLATFORMS
 
 DEPENDENCIES
   graphql
+  pg
   puma
+  rake
+  sequel
+  sequel-rake
   sinatra
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+#Rakefile
+
+require 'sequel/rake'
+Sequel::Rake.load!

--- a/db/migrations/1506198041_create_sectors.rb
+++ b/db/migrations/1506198041_create_sectors.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:sectors) do
+        primary_key :id
+        String :name, null: false, unique: true
+        String :slug, null: false, index: true, unique: true
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506199298_create_companies.rb
+++ b/db/migrations/1506199298_create_companies.rb
@@ -11,7 +11,7 @@ Sequel.migration do
         String :location
         String :website_uri
         String :careers_uri
-        Float :rating
+        BigDecimal :rating, size: [8, 2]
 
         DateTime :created_at, default: Sequel::SQL::Function.new(:now)
         DateTime :updated_at, default: Sequel::SQL::Function.new(:now)

--- a/db/migrations/1506199298_create_companies.rb
+++ b/db/migrations/1506199298_create_companies.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:companies) do
+        primary_key :id
+
+        String :name, null: false
+        String :slug, null: false, index: true, unique: true
+        String :description, text: true
+        String :location
+        String :website_uri
+        String :careers_uri
+        Float :rating
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506199566_create_companies_sectors.rb
+++ b/db/migrations/1506199566_create_companies_sectors.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+    change do
+        create_join_table(company_id: :companies, sector_id: :sectors)
+    end
+end

--- a/db/migrations/1506200107_create_benefits.rb
+++ b/db/migrations/1506200107_create_benefits.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:benefits) do
+        primary_key :id
+
+        String :name, null: false, unique: true
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506200152_create_benefits_companies.rb
+++ b/db/migrations/1506200152_create_benefits_companies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_join_table(benefit_id: :benefits, company_id: :companies)
+  end
+end

--- a/db/migrations/1506200226_create_questions.rb
+++ b/db/migrations/1506200226_create_questions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:questions) do
+        primary_key :id
+
+        String :name, null: false, unique: true
+        String :template, null: false
+        String :title, null: false
+        String :help_text
+        Integer :group
+        String :settings, text: true
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506200234_create_question_options.rb
+++ b/db/migrations/1506200234_create_question_options.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:question_options) do
+        primary_key :id
+        foreign_key :question_id, :questions
+
+        String :option, null: false
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506202163_create_submissions.rb
+++ b/db/migrations/1506202163_create_submissions.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:submissions) do
+        primary_key :id
+        foreign_key :company_id, :companies
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end

--- a/db/migrations/1506202166_create_submission_answers.rb
+++ b/db/migrations/1506202166_create_submission_answers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:submission_answers) do
+        primary_key :id
+        foreign_key :question_id, :questions
+        foreign_key :question_option_id, :question_options, null: true
+
+        String :answer, text: true
+
+        DateTime :created_at, default: Sequel::SQL::Function.new(:now)
+        DateTime :updated_at, default: Sequel::SQL::Function.new(:now)
+    end
+  end
+end


### PR DESCRIPTION
Work Done:

- Added `rake` and `rake-sequel` gems for easily creating migrations
- Added initial DB structure to be migrated

**NOTE**

Before migrations can be run, you will need to have a `DATABASE_URL` environment variable.

eg: `DATABASE_URL=postgres://postgres@localhost/goodforpoc_development`

This could be added to the Dockerfile for development?