### PR TITLE
[Feature] Question Pages

### DIFF
--- a/db/migrations/1507032387_create_question_pages.rb
+++ b/db/migrations/1507032387_create_question_pages.rb
@@ -6,6 +6,7 @@ Sequel.migration do
       primary_key :id
 
       String :title, null: false
+      Integer :page, index: true, unique: true
       jsonb :attributes
     end
   end

--- a/db/migrations/1507032387_create_question_pages.rb
+++ b/db/migrations/1507032387_create_question_pages.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  change do
+    create_table(:question_pages) do
+      primary_key :id
+
+      String :title, null: false
+      jsonb :attributes
+    end
+  end
+end

--- a/db/migrations/1507033383_add_question_page_to_questions.rb
+++ b/db/migrations/1507033383_add_question_page_to_questions.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    alter_table(:questions) do
+      drop_column :group
+
+      add_foreign_key(:question_page_id, :question_pages)
+    end
+  end
+
+  down do
+    alter_table(:questions) do
+      drop_foreign_key :question_page_id
+
+      add_column :group, Integer
+    end
+  end
+end

--- a/mock-api/lib/db.js
+++ b/mock-api/lib/db.js
@@ -9,15 +9,22 @@ module.exports = {
         { id: 1, company_id: 1, location_id: 1}
     ],
     benefits: [
-        { id: 1, name: 'Remote Working'},
+        { id: 1, name: 'Remote Working'}
     ],
     benefits_companies: [
         { id: 1, benefit_id: 1, company_id: 1}
     ],
+    question_pages: [
+      { id: 1, title: "Part 1: About You", page: 1},
+      { id: 2, title: "Part 2: Company Info", page: 2}
+    ],
     questions: [
-        { id: 1, name: 'ethnicity', template: 'checkbox', title: 'Race / Ethnicity', help_text: 'Your racial or ethnic identity (optional – select multiple if multiracial)', group: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
-        { id: 2, name: 'department', template: 'radio', title: 'Department', help_text: 'Your position at the company you are submitting (optional)', group: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
-        { id: 3, name: 'length-of-employment', template: 'radio', title: 'Length of Employment', help_text: 'How long you\'ve worked at this company (optional)', group: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')}
+        { id: 1, name: 'ethnicity', template: 'checkbox', title: 'Race / Ethnicity', help_text: 'Your racial or ethnic identity (optional – select multiple if multiracial)', question_page_id: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 2, name: 'department', template: 'radio', title: 'Department', help_text: 'Your position at the company you are submitting (optional)', question_page_id: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 3, name: 'length-of-employment', template: 'radio', title: 'Length of Employment', help_text: 'How long you\'ve worked at this company (optional)', question_page_id: 1, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 4, name: 'company-name', template: 'textbox', title: 'Company Name', question_page_id: 2, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 5, name: 'company-website', template: 'textbox', title: 'Company Website', question_page_id: 2, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 6, name: 'sectors', template: 'checkbox', title: 'Categories', question_page_id: 2, created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')}
     ],
     question_options: [
         { id: 5, question_id: 1, option: 'Asian (East Asian, Southeast Asian, Indian, etc.)', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
@@ -30,6 +37,9 @@ module.exports = {
         { id: 5, question_id: 3, option: '0-11 months', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
         { id: 6, question_id: 3, option: '1-2 years', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
         { id: 7, question_id: 3, option: '3-4 years', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
-        { id: 8, question_id: 3, option: '5+ years', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')}
+        { id: 8, question_id: 3, option: '5+ years', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 9, question_id: 6, option: 'Software', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 10, question_id: 6, option: 'Health', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')},
+        { id: 11, question_id: 6, option: 'Education', created_at: new Date('2017-09-25'), updated_at: new Date('2017-09-25')}
     ]
 }


### PR DESCRIPTION
Work Done:

- Added the ability to create Question "Pages". This allows us to easily create "Part 1", "Part 2" of the questionaire whilst also being able to specify the title for each part.
- Updated the mock API to reflect above changes

*Note*

I've added a JSONB field called `attributes` - this will allow us to add custom fields to a page as and when we need them, without going down the route of EAV tables which is painful af.