### PR TITLE
[Feature] Add task for seeding DB

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,9 +19,6 @@ namespace :db do
 
     Sequel.extension :seed
     Sequel::Seed.setup(ENV['RACK_ENV'].to_sym || :development)
-
-    DB[:schema_seeds].delete
-
     Sequel::Seeder.apply(DB, "db/seeds")
 
     puts 'The database was seeded!'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'config/environment'
+
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:test)
@@ -9,3 +11,19 @@ end
 
 require 'sequel/rake'
 Sequel::Rake.load!
+
+namespace :db do
+  desc "Run the seeds against the database"
+  task :seed do
+    require 'sequel/extensions/seed'
+
+    Sequel.extension :seed
+    Sequel::Seed.setup(ENV['RACK_ENV'].to_sym || :development)
+
+    DB[:schema_seeds].delete
+
+    Sequel::Seeder.apply(DB, "db/seeds")
+
+    puts 'The database was seeded!'
+  end
+end

--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ namespace :db do
     require 'sequel/extensions/seed'
 
     Sequel.extension :seed
-    Sequel::Seed.setup(ENV['RACK_ENV'].to_sym || :development)
+    Sequel::Seed.setup(ENV['RACK_ENV'].to_sym)
     Sequel::Seeder.apply(DB, "db/seeds")
 
     puts 'The database was seeded!'


### PR DESCRIPTION
Work Done:

- Loaded `config/environment` to give rake tasks access to the global `DB` variable etc
- Added task to run seeds against the DB