### PR TITLE
[WIP] [Feature] Run Database Migrations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,14 @@ COPY ["Gemfile*", "$APP_DIR/"]
 WORKDIR $APP_DIR
 
 RUN bundle install --binstubs=bin --deployment
+RUN bundle update --full-index
 
 COPY . .
 VOLUME ["$APP_DIR/"]
 
-ENTRYPOINT ["bundle", "exec"]
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]
+
 CMD ["puma", "-C", "config/puma.rb"]

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'config/environment'
+
 begin
   require 'rspec/core/rake_task'
   RSpec::Core::RakeTask.new(:test)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - 'PORT=9292'
       - 'RACK_ENV=development'
       - 'BUNDLE_CACHE=/app/vendor/cache'
-      - 'DATABASE_URL=postgres://g4poc:*(g4p0c_@psql:5432'
+      - 'DATABASE_URL=postgres://g4poc:*(g4p0c_@psql:5432/g4poc'
       - 'APP_DIR=/app'
       - 'MOCK_GRAPHQL_SERVER_HOST=http://mock_graphql_api:3000'
     depends_on:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+# Run migrations
+rake sequel:migrate
+
+exec "$@"


### PR DESCRIPTION
Work Done:

- Set `ENTRYPOINT` in `Dockerfile` to be `docker-entrypoint.sh`
- Fixed `DATABASE_URL` so migrations run successfully

**Note:**

I was getting `Bundler::GemNotFound: Could not find concurrent-ruby-1.0.5 in any of the sources` errors when re-building the docker container. Not sure why exactly, but I added `bundle update --full-index` which is supposedly the way to fix the issue. Is this fine to add here?

From the docs:

> Bundler will not call Rubygems' API endpoint (default) but download and cache a (currently big) index file of all gems. Performance can be improved for large bundles that seldomly change by enabling this option.